### PR TITLE
Security fix: eslint-utils upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,16 +32,28 @@
       }
     },
     "@ngx-rocket/core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@ngx-rocket/core/-/core-5.0.1.tgz",
-      "integrity": "sha512-gJzjAWMwPl0JPPObw7NnFpMoPYmP006suPyMrXbcXNIkByte69ARPvqzBc5ZUY5hsvauLLqnFxd2d25j7ZWBcQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ngx-rocket/core/-/core-5.0.2.tgz",
+      "integrity": "sha512-da/UZ2FtBgE+UbKQzplEVmCjHhY9X6DpNnCfxgzxq7pvUIbkeNDuFEy6ysyE2suq/y/SwEzxKuyezfIWwjDYbg==",
       "requires": {
         "chalk": "^2.4.2",
-        "ejs": "^2.6.2",
-        "ignore": "^5.1.2",
-        "lodash": "^4.17.11",
+        "ejs": "^2.7.1",
+        "ignore": "^5.1.4",
+        "lodash": "^4.17.15",
         "node-dir": "^0.1.14",
-        "yeoman-generator": "^4.0.1"
+        "yeoman-generator": "^4.0.2"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "@nodelib/fs.stat": {
@@ -210,11 +222,11 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.14"
       }
     },
     "atob": {
@@ -821,18 +833,25 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "editions": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
-      "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.2.0.tgz",
+      "integrity": "sha512-RYg3iEA2BDLCNVe8PUkD+ox5vAKxB9XS/mAhx1bdxGCF0CpX077C0pyTA9t5D6idCYA3avl5/XDHKPsHFrygfw==",
       "requires": {
-        "errlop": "^1.1.1",
-        "semver": "^5.6.0"
+        "errlop": "^1.1.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "ejs": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
-      "integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q=="
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.1.tgz",
+      "integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ=="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -856,20 +875,19 @@
       "dev": true
     },
     "errlop": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz",
-      "integrity": "sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.2.tgz",
+      "integrity": "sha512-djkRp+urJ+SmqDBd7F6LUgm4Be1TTYBxia2bhjNdFBuBDQtJDHExD2VbxR6eyst3h1TZy3qPRCdqb6FBoFttTA==",
       "requires": {
-        "editions": "^2.1.2"
+        "editions": "^2.1.3"
       }
     },
     "error": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.2.0.tgz",
+      "integrity": "sha512-M6t3j3Vt3uDicrViMP5fLq2AeADNrCVFD8Oj4Qt2MHsX0mPYG7D5XdnEfSdRpaHQzjAJ19wu+I1mw9rQYMTAPg==",
       "requires": {
-        "string-template": "~0.2.1",
-        "xtend": "~4.0.0"
+        "string-template": "~0.2.1"
       }
     },
     "error-ex": {
@@ -1988,7 +2006,8 @@
     "ignore": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
-      "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ=="
+      "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+      "dev": true
     },
     "import-fresh": {
       "version": "3.1.0",
@@ -2372,9 +2391,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.1.tgz",
-      "integrity": "sha512-bvJxbNWm72dy/1+qeBm9F8wUM4siDnlzid7NN5Ib4nQcc0tNIx/YWgEih1ZRHXr8xVbpGk1ccLlA9gOSlyx3gw=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.2.tgz",
+      "integrity": "sha512-C3FSxJdNrEr2F4z6uFtNzECDM5hXk+46fxaa+cwBe5/XrWSmzdG8DDgyjfX6/NRdBB21q2JXuRAzPCUs+fclnQ=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -2608,9 +2627,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -3498,9 +3517,9 @@
       }
     },
     "pretty-bytes": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.2.0.tgz",
-      "integrity": "sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -4059,18 +4078,11 @@
       }
     },
     "string_decoder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -4197,9 +4209,9 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "textextensions": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.4.0.tgz",
-      "integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.5.0.tgz",
+      "integrity": "sha512-1IkVr355eHcomgK7fgj1Xsokturx6L5S2JRT5WcRdA6v5shk9sxWuO/w/VbpQexwkXJMQIa/j1dBi3oo7+HhcA=="
     },
     "the-argv": {
       "version": "1.0.0",
@@ -4894,9 +4906,9 @@
       }
     },
     "yeoman-generator": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-4.0.1.tgz",
-      "integrity": "sha512-QFSHcJHfDwqNdcr5RPSCPLnRzVpPuDWb6By2Uz77YByqBqvR/r9QGBucCl58hs5QJl4NFgLFgIHZoNDCJP1byA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-4.1.0.tgz",
+      "integrity": "sha512-AULpLsX2CYr0sweIp03isXTl17YkBOOrqzpnErtYr0pUZz4ICqvJbvDPaC/ETMyf0bXHiuY56ATxSKDC/AXHWw==",
       "requires": {
         "async": "^2.6.2",
         "chalk": "^2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1359,10 +1359,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.1.tgz",
+      "integrity": "sha512-mRQKp/gEImJj7aP2be4F0cIQMxlgY9em9RFtxDmkwqV3cUKCK/mvso36wGQFJCNnrBKrEMBZkOLDrMSM+BpG3A==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/ngx-rocket/addon-firebase/issues"
   },
   "dependencies": {
-    "@ngx-rocket/core": "^5.0.1",
+    "@ngx-rocket/core": "^5.0.2",
     "chalk": "^2.4.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "chalk": "^2.4.2"
   },
   "devDependencies": {
-    "xo": "^0.24.0"
+    "xo": "^0.24.0",
+    "eslint-utils": "1.4.1"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
A better fix would be to move to eslint 6.0, but that's a larger step to take.